### PR TITLE
create lib folder if not exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "jest",
     "prepublish": "yarn run build",
-    "build": "babel index.js --out-file lib/index.js"
+    "build": "mkdir -p lib && babel index.js --out-file lib/index.js"
   },
   "dependencies": {
     "browserslist": "^2.9.1",


### PR DESCRIPTION
It was impossible to install your package without having a lib folder